### PR TITLE
Update outdated code in handler pii tutorial

### DIFF
--- a/Getting Started/Pre-Processing/handling_pii.ipynb
+++ b/Getting Started/Pre-Processing/handling_pii.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:29.683248Z",
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.168933Z",
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.221294Z",
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.465056Z",
@@ -112,9 +112,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\r\n",
-      "                                 Dload  Upload   Total   Spent    Left  Speed\r\n",
-      "100  4748  100  4748    0     0  41635      0 --:--:-- --:--:-- --:--:-- 42017\r\n"
+      "File ‘sample-data.csv’ already there; not retrieving.\n",
+      "\n"
      ]
     }
    ],
@@ -124,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.476954Z",
@@ -148,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.499901Z",
@@ -874,7 +873,7 @@
        "29      rzwick@domain.com       v  5252 5971 4219 4116     173    2011/02/01  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -923,7 +922,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.522287Z",
@@ -959,7 +958,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.559797Z",
@@ -1001,7 +1000,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.586634Z",
@@ -1042,7 +1041,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.603977Z",
@@ -1086,7 +1085,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.615203Z",
@@ -1130,7 +1129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.619079Z",
@@ -1169,7 +1168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.624165Z",
@@ -1193,7 +1192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.629217Z",
@@ -1226,7 +1225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.633767Z",
@@ -1261,7 +1260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.644850Z",
@@ -1278,7 +1277,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Workflow: 1W58Q0QsW0z1kvx2kIRoVI\n"
+      "Workflow: 6fMF4lVuFzRBeWPoSu1hRy\n"
      ]
     }
    ],
@@ -1291,7 +1290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.688076Z",
@@ -1308,9 +1307,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2024-12-12T22:31:30.648394Z dataset-load: INFO Loading dataset '1mjABBrolgVt8fG2VWm5d7' with 30 rows\n",
-      "2024-12-12T22:31:30.686169Z dataset-save: WARN No session metadata provided\n",
-      "2024-12-12T22:31:30.686511Z dataset-save: INFO Saved dataset '7871JhUC33hHd9aaHtbJXb' with 30 rows\n"
+      "2026-01-21T18:49:01.808236Z dataset-load: INFO Downloading dataset '5ickqviyC7dE1Z02infG4T'\n",
+      "2026-01-21T18:49:01.810713Z dataset-load: INFO Downloaded dataset '5ickqviyC7dE1Z02infG4T' with 30 rows\n",
+      "2026-01-21T18:49:01.847974Z dataset-save: WARN No session metadata provided\n",
+      "2026-01-21T18:49:01.848095Z dataset-save: INFO Saved dataset '6ZXhdA79mSCbmnc2D9fPyO' with 30 rows\n"
      ]
     }
    ],
@@ -1321,7 +1321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.693903Z",
@@ -1346,7 +1346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.701633Z",
@@ -1443,7 +1443,7 @@
        "9  421XXXXXXXX"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1454,7 +1454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.723096Z",
@@ -1562,7 +1562,7 @@
        "9  1980/04/09           Apr 1980"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1573,7 +1573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.765897Z",
@@ -1681,7 +1681,7 @@
        "9    sdavis@domain.com         Jo.Miller@golden-bolton.info"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1692,7 +1692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.824312Z",
@@ -1800,7 +1800,7 @@
        "9  205-221-9156    295.333.0413x5256"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1811,7 +1811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.859151Z",
@@ -1919,7 +1919,7 @@
        "9      33                0"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1930,7 +1930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:30.934864Z",
@@ -2038,7 +2038,7 @@
        "9      f          Female"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2067,7 +2067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.238277Z",
@@ -2084,9 +2084,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\r\n",
-      "                                 Dload  Upload   Total   Spent    Left  Speed\r\n",
-      "100  7043  100  7043    0     0  52584      0 --:--:-- --:--:-- --:--:-- 52954\r\n"
+      "File ‘pcap.csv’ already there; not retrieving.\n",
+      "\n"
      ]
     }
    ],
@@ -2105,7 +2104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.257721Z",
@@ -2129,7 +2128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.280613Z",
@@ -2319,7 +2318,7 @@
        "[100 rows x 7 columns]"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2346,7 +2345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.308298Z",
@@ -2370,7 +2369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.335713Z",
@@ -2394,7 +2393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.358716Z",
@@ -2412,7 +2411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.379638Z",
@@ -2442,7 +2441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.392041Z",
@@ -2459,7 +2458,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Workflow: 5Cv1ID7yIYm0YjxjFruMwJ\n"
+      "Workflow: 4KwzS0dnIR440VNgn78O6L\n"
      ]
     }
    ],
@@ -2472,7 +2471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.403401Z",
@@ -2489,9 +2488,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2024-12-12T22:31:31.395453Z dataset-load: INFO Loading dataset '3sLFNxc4BuoMBZVUFgoLxS' with 100 rows\n",
-      "2024-12-12T22:31:31.396429Z dataset-save: WARN No session metadata provided\n",
-      "2024-12-12T22:31:31.396649Z dataset-save: INFO Saved dataset '5aiXif7bX42inHUWTtjY62' with 100 rows\n"
+      "2026-01-21T18:49:02.126057Z dataset-load: INFO Downloading dataset '7f13K6g2jGf9ji4kjxThKu'\n",
+      "2026-01-21T18:49:02.129405Z dataset-save: WARN No session metadata provided\n",
+      "2026-01-21T18:49:02.127732Z dataset-load: INFO Downloaded dataset '7f13K6g2jGf9ji4kjxThKu' with 100 rows\n",
+      "2026-01-21T18:49:02.129530Z dataset-save: INFO Saved dataset '7v6HjQ7DadXP7wDRR7lbox' with 100 rows\n"
      ]
     }
    ],
@@ -2502,7 +2502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.440979Z",
@@ -2527,7 +2527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-12-12T22:31:31.458444Z",
@@ -2570,52 +2570,52 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>244.3.253.224</td>\n",
-       "      <td>244.3.253.89</td>\n",
+       "      <td>244.3.253.39</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>41.177.26.91</td>\n",
-       "      <td>41.177.26.254</td>\n",
+       "      <td>41.177.26.220</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>41.177.26.91</td>\n",
-       "      <td>41.177.26.254</td>\n",
+       "      <td>41.177.26.220</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>41.177.26.91</td>\n",
-       "      <td>41.177.26.254</td>\n",
+       "      <td>41.177.26.220</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>41.177.26.91</td>\n",
-       "      <td>41.177.26.254</td>\n",
+       "      <td>41.177.26.220</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>244.3.160.239</td>\n",
-       "      <td>244.3.160.125</td>\n",
+       "      <td>244.3.160.205</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>41.177.26.91</td>\n",
-       "      <td>41.177.26.254</td>\n",
+       "      <td>41.177.26.220</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>41.177.26.91</td>\n",
-       "      <td>41.177.26.254</td>\n",
+       "      <td>41.177.26.220</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>244.3.160.80</td>\n",
-       "      <td>244.3.160.168</td>\n",
+       "      <td>244.3.160.77</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>244.3.160.239</td>\n",
-       "      <td>244.3.160.125</td>\n",
+       "      <td>244.3.160.205</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2623,19 +2623,19 @@
       ],
       "text/plain": [
        "           srcip remapped_srcip\n",
-       "0  244.3.253.224   244.3.253.89\n",
-       "1   41.177.26.91  41.177.26.254\n",
-       "2   41.177.26.91  41.177.26.254\n",
-       "3   41.177.26.91  41.177.26.254\n",
-       "4   41.177.26.91  41.177.26.254\n",
-       "5  244.3.160.239  244.3.160.125\n",
-       "6   41.177.26.91  41.177.26.254\n",
-       "7   41.177.26.91  41.177.26.254\n",
-       "8   244.3.160.80  244.3.160.168\n",
-       "9  244.3.160.239  244.3.160.125"
+       "0  244.3.253.224   244.3.253.39\n",
+       "1   41.177.26.91  41.177.26.220\n",
+       "2   41.177.26.91  41.177.26.220\n",
+       "3   41.177.26.91  41.177.26.220\n",
+       "4   41.177.26.91  41.177.26.220\n",
+       "5  244.3.160.239  244.3.160.205\n",
+       "6   41.177.26.91  41.177.26.220\n",
+       "7   41.177.26.91  41.177.26.220\n",
+       "8   244.3.160.80   244.3.160.77\n",
+       "9  244.3.160.239  244.3.160.205"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Update the old `preprocess_builder.actions` to `preprocess_builder._actions` since the old code no longer works. This was likely missed when the SDK was updated, and the notebooks were not updated at that time.